### PR TITLE
Settings `pairs = NULL` by default. 

### DIFF
--- a/R/add_pval_ggplot.R
+++ b/R/add_pval_ggplot.R
@@ -136,7 +136,7 @@ add_pval <- function(ggplot_obj,
                      response="infer",
                      ...){
   
-  pairs fix ---------------------------------------------------------------
+# pairs fix ---------------------------------------------------------------
   if(is.null(pairs)){
     total_groups <- length(unique(ggplot_obj$data[[ggpval:::get_in_parenthesis(as.character(ggplot_obj$mapping[1]))]]))
     

--- a/R/add_pval_ggplot.R
+++ b/R/add_pval_ggplot.R
@@ -121,7 +121,7 @@ infer_response <- function(ggplot_obj){
 #' @export
 
 add_pval <- function(ggplot_obj,
-                     pairs=list(c(1,2),c(1,3)),
+                     pairs=NULL,
                      test="wilcox.test",
                      heights=NULL,
                      barheight=NULL,
@@ -135,6 +135,20 @@ add_pval <- function(ggplot_obj,
                      parse_text=NULL,
                      response="infer",
                      ...){
+  
+  pairs fix ---------------------------------------------------------------
+  if(is.null(pairs)){
+    total_groups <- length(unique(ggplot_obj$data[[ggpval:::get_in_parenthesis(as.character(ggplot_obj$mapping[1]))]]))
+    
+    if(total_groups==2){
+      pairs <- list(c(1,2))
+    } else {
+      pairs <- lapply(2:total_groups, function(x) c(1,x))
+    }
+  }
+# -------------------------------------------------------------------------
+  
+  
   if (is.null(parse_text)){
     if (is.null(annotation)){
       parse_text <- TRUE


### PR DESCRIPTION
I had a dataset with only two groups and I kept getting 
```r
> add_pval(p1)
Error in wilcox.test.formula(data = data_2_test, response ~ group__, ...) : 
  grouping factor must have exactly 2 levels
```
It took me a stupid amount of time to figure out that `pairs = list(c(1,2), c(1,3)` is the default and I need to make sure to set `pairs` explicitly every time. 

You could place 
```r
if(is.null(pairs)){
  total_groups <- length(unique(ggplot_obj$data[, get(ggpval:::get_in_parenthesis(as.character(ggplot_obj$mapping[1])))]))
  
  if(total_groups==2){
    pairs <- list(c(1,2))
  } else {
    pairs <- lapply(2:total_groups, function(x) c(1,x))
  }
  ``` 
 right in the beginning with `pairs = NULL` in the arguments. For simple plots, you could just use `add_pval(plot)` for simplicity. 